### PR TITLE
Eliminating stats callback

### DIFF
--- a/sead-cp/src/main/java/org/sead/cp/ResearchObjects.java
+++ b/sead-cp/src/main/java/org/sead/cp/ResearchObjects.java
@@ -40,7 +40,8 @@ public abstract class ResearchObjects {
 	 * 
 	 * @param publicationRequest
 	 *            {Aggregation, &lt;ContentObject&gt;, Preferences, {&lt;Preferences
-	 *            list&gt;}, Repository, &lt;RepositoryId&gt;}}
+	 *            list&gt;}, Aggregation Statistics {&lt;Aggregation Statistics List
+	 *            &gt; Repository, &lt;RepositoryId&gt;}}
 	 * 
 	 * <br>
 	 *            where Content is a json object including basic metadata and

--- a/sead-cp/src/main/java/org/sead/cp/ResearchObjects.java
+++ b/sead-cp/src/main/java/org/sead/cp/ResearchObjects.java
@@ -73,13 +73,15 @@ public abstract class ResearchObjects {
 	 * 
 	 * @param publicationRequest
 	 *            {Aggregation, &lt;Aggregation&gt;, Preferences, {&lt;Preferences
-	 *            list&gt;} }}
+	 *            list&gt;}, Aggregation Statistics {&lt;Aggregation Statistics List
+	 *            &gt;} }}
 	 * 
 	 * <br>
 	 *            where Aggregation is a json object including basic metadata and
 	 *            the unique ID for the entity the user wants to publish. <br>
 	 *            preferences is a json list of options chosen from those
-	 *            available (see api ____) <br>
+	 *            available (see api ____), and Aggregation Statistics are values for metadata that 
+	 *            correspond to the rule matching requirements <br>
 	 * 
 	 * @see Example input file: _______ <br>
 	 *      Example output file: _______

--- a/sead-cp/src/main/java/org/sead/cp/demo/Matcher.java
+++ b/sead-cp/src/main/java/org/sead/cp/demo/Matcher.java
@@ -26,7 +26,7 @@ import org.bson.types.BasicBSONList;
 
 public interface Matcher {
 	public RuleResult runRule(Document aggregation, 
-			BasicBSONList affiliations, Document preferences, Document profile);
+			BasicBSONList affiliations, Document preferences, Document stats, Document profile);
 
 	public String getName();
 

--- a/sead-cp/src/main/java/org/sead/cp/demo/ResearchObjectsImpl.java
+++ b/sead-cp/src/main/java/org/sead/cp/demo/ResearchObjectsImpl.java
@@ -121,6 +121,10 @@ public class ResearchObjectsImpl extends ResearchObjects {
 		if (repository == null) {
 			messageString += "Missing Respository";
 		}
+		Document stats = (Document) request.get("Aggregation Statistics");
+		if (stats == null) {
+			messageString += "Missing Statistics";
+		}
 		if (messageString == null) {
 			// Get organization from profile(s)
 			// Add to base document
@@ -333,6 +337,11 @@ public class ResearchObjectsImpl extends ResearchObjects {
 		if (preferences == null) {
 			messageString += "Missing Preferences";
 		}
+		Document stats = (Document) request.get("Aggregation Statistics");
+		if (stats == null) {
+			messageString += "Missing Statistics";
+		}
+
 		if (messageString == null) {
 			// Get organization from profile(s)
 			// Add to base document
@@ -386,7 +395,7 @@ public class ResearchObjectsImpl extends ResearchObjects {
 					BasicBSONObject individualScore = new BasicBSONObject();
 
 					RuleResult result = m.runRule(content, affiliations,
-							preferences, profile);
+							preferences, stats, profile);
 
 					individualScore.put("Rule Name", m.getName());
 					if (result.wasTriggered()) {

--- a/sead-cp/src/main/java/org/sead/cp/demo/matchers/DataTypeMatcher.java
+++ b/sead-cp/src/main/java/org/sead/cp/demo/matchers/DataTypeMatcher.java
@@ -40,24 +40,10 @@ import com.sun.jersey.api.client.WebResource;
 
 public class DataTypeMatcher implements Matcher {
 
-	public RuleResult runRule(Document aggregation,
-			BasicBSONList affiliations, Document preferences, Document profile) {
+	public RuleResult runRule(Document aggregation, BasicBSONList affiliations,
+			Document preferences, Document statsDocument, Document profile) {
 		RuleResult result = new RuleResult();
-		Client client = Client.create();
-		WebResource webResource;
 		try {
-			webResource = client.resource(aggregation.get("similarTo") + "/stats");
-
-			ClientResponse response = webResource.accept("application/json")
-					.get(ClientResponse.class);
-
-			if (response.getStatus() != 200) {
-				throw new RuntimeException("" + response.getStatus());
-			}
-
-			Document statsDocument = Document.parse(response
-					.getEntity(String.class));
-
 			@SuppressWarnings("unchecked")
 			ArrayList<String> existingTypes = (ArrayList<String>) statsDocument
 					.get("Data Mimetypes");
@@ -91,7 +77,7 @@ public class DataTypeMatcher implements Matcher {
 			System.out.println("Missing info in MaxDepth rule for repo: "
 					+ profile.getString("orgidentifier") + " : "
 					+ nfe.getLocalizedMessage());
-		} 
+		}
 		return result;
 
 	}

--- a/sead-cp/src/main/java/org/sead/cp/demo/matchers/DataTypeMatcher.java
+++ b/sead-cp/src/main/java/org/sead/cp/demo/matchers/DataTypeMatcher.java
@@ -70,11 +70,11 @@ public class DataTypeMatcher implements Matcher {
 			}
 		} catch (NullPointerException npe) {
 			// Just return untriggered result
-			System.out.println("Missing info in MaximumDepth rule"
+			System.out.println("Missing info in AcceptableDataTypes rule"
 					+ npe.getLocalizedMessage());
 		} catch (NumberFormatException nfe) {
 			// Just return untriggered result
-			System.out.println("Missing info in MaxDepth rule for repo: "
+			System.out.println("Missing info in AcceptableDataTypes rule for repo: "
 					+ profile.getString("orgidentifier") + " : "
 					+ nfe.getLocalizedMessage());
 		}

--- a/sead-cp/src/main/java/org/sead/cp/demo/matchers/DepthMatcher.java
+++ b/sead-cp/src/main/java/org/sead/cp/demo/matchers/DepthMatcher.java
@@ -35,23 +35,10 @@ import com.sun.jersey.api.client.WebResource;
 
 public class DepthMatcher implements Matcher {
 
-	public RuleResult runRule(Document aggregation,
-			BasicBSONList affiliations, Document preferences, Document profile) {
+	public RuleResult runRule(Document aggregation, BasicBSONList affiliations,
+			Document preferences, Document statsDocument, Document profile) {
 		RuleResult result = new RuleResult();
-		Client client = Client.create();
-		WebResource webResource;
 		try {
-			webResource = client.resource(aggregation.getString("similarTo") + "/stats");
-
-			ClientResponse response = webResource.accept("application/json")
-					.get(ClientResponse.class);
-
-			if (response.getStatus() != 200) {
-				throw new RuntimeException("" + response.getStatus());
-			}
-
-			Document statsDocument = Document.parse(response
-					.getEntity(String.class));
 
 			long max = Long.parseLong(statsDocument
 					.getString("Max Collection Depth"));
@@ -74,7 +61,7 @@ public class DepthMatcher implements Matcher {
 			System.out.println("Missing info in MaxDepth rule for repo: "
 					+ profile.getString("orgidentifier") + " : "
 					+ nfe.getLocalizedMessage());
-		} 
+		}
 		return result;
 
 	}

--- a/sead-cp/src/main/java/org/sead/cp/demo/matchers/MaxDatasetSizeMatcher.java
+++ b/sead-cp/src/main/java/org/sead/cp/demo/matchers/MaxDatasetSizeMatcher.java
@@ -36,23 +36,10 @@ import com.sun.jersey.api.client.WebResource;
 
 public class MaxDatasetSizeMatcher implements Matcher {
 
-	public RuleResult runRule(Document aggregation, 
-			BasicBSONList affiliations, Document preferences, Document profile) {
+	public RuleResult runRule(Document aggregation, BasicBSONList affiliations,
+			Document preferences, Document statsDocument, Document profile) {
 		RuleResult result = new RuleResult();
-		Client client = Client.create();
-		WebResource webResource;
 		try {
-			webResource = client.resource(aggregation.get("similarTo") + "/stats");
-
-			ClientResponse response = webResource.accept("application/json")
-					.get(ClientResponse.class);
-
-			if (response.getStatus() != 200) {
-				throw new RuntimeException("" + response.getStatus());
-			}
-
-			Document statsDocument = Document.parse(response
-					.getEntity(String.class));
 
 			long max = Long.parseLong(statsDocument
 					.getString("Max Dataset Size"));
@@ -67,14 +54,14 @@ public class MaxDatasetSizeMatcher implements Matcher {
 			}
 		} catch (NullPointerException npe) {
 			// Just return untriggered result
-			System.out.println("Missing info in MaxDatasetSize rule"
+			System.out.println("Missing info in MaxDatasetSize rule: "
 					+ npe.getLocalizedMessage());
 		} catch (NumberFormatException nfe) {
 			// Just return untriggered result
 			System.out.println("Missing info in MaxDatasetSize rule for repo: "
 					+ profile.getString("orgidentifier") + " : "
 					+ nfe.getLocalizedMessage());
-		} 
+		}
 		return result;
 
 	}

--- a/sead-cp/src/main/java/org/sead/cp/demo/matchers/MaxTotalSizeMatcher.java
+++ b/sead-cp/src/main/java/org/sead/cp/demo/matchers/MaxTotalSizeMatcher.java
@@ -36,25 +36,11 @@ import com.sun.jersey.api.client.WebResource;
 public class MaxTotalSizeMatcher implements Matcher {
 
 	public RuleResult runRule(Document aggregation, BasicBSONList affiliations,
-			Document preferences, Document profile) {
+			Document preferences, Document statsDocument, Document profile) {
 		RuleResult result = new RuleResult();
-		Client client = Client.create();
-		WebResource webResource;
-
+	
 		try {
-			webResource = client.resource(aggregation.get("similarTo")
-					+ "/stats");
-
-			ClientResponse response = webResource.accept("application/json")
-					.get(ClientResponse.class);
-
-			if (response.getStatus() != 200) {
-				throw new RuntimeException("" + response.getStatus());
-			}
-
-			Document statsDocument = Document.parse(response
-					.getEntity(String.class));
-
+	
 			long max = Long.parseLong(statsDocument.getString("Total Size"));
 			long repoMax = Long.parseLong(profile.getString("Total Size"));
 			if (max > repoMax) {

--- a/sead-cp/src/main/java/org/sead/cp/demo/matchers/MinimalMetadataMatcher.java
+++ b/sead-cp/src/main/java/org/sead/cp/demo/matchers/MinimalMetadataMatcher.java
@@ -28,7 +28,7 @@ import org.sead.cp.demo.RuleResult;
 public class MinimalMetadataMatcher implements Matcher {
 
 	public RuleResult runRule(Document aggregation, 
-			BasicBSONList affiliations, Document preferences, Document profile) {
+			BasicBSONList affiliations, Document preferences, Document statsDocument, Document profile) {
 
 		return new RuleResult();
 	}

--- a/sead-cp/src/main/java/org/sead/cp/demo/matchers/OrganizationMatcher.java
+++ b/sead-cp/src/main/java/org/sead/cp/demo/matchers/OrganizationMatcher.java
@@ -32,7 +32,7 @@ import org.sead.cp.demo.RuleResult;
 public class OrganizationMatcher implements Matcher {
 
 	public RuleResult runRule(Document aggregation, BasicBSONList affiliations,
-			Document Preferences, Document profile) {
+			Document Preferences, Document statsDocument, Document profile) {
 		RuleResult result = new RuleResult();
 		try {
 			ArrayList<String> requiredAffiliations = (ArrayList<String>) profile


### PR DESCRIPTION
After discussion with multiple people: removing the undocumented callback used by the demo matchers to get stats and making aggregation stats part of the matching request (doesn't change the API calls, but adds one section to the required info in a matching request, simplifies the demo matchers and removes the need for Matchmaker to know about the callback (which was 1.5. specific at this point too). 
